### PR TITLE
main: skip missing swagger files instead of failing

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,8 @@ func main() {
 		fmt.Printf("Reading REST file %s\n", restFile)
 		restBytes, err := ioutil.ReadFile(restFile)
 		if err != nil {
-			fail(err)
+			fmt.Printf("Skipping missing REST file\n")
+			continue
 		}
 
 		rest := &Swagger{}
@@ -110,6 +111,7 @@ func main() {
 	if err != nil {
 		fail(err)
 	}
+	fmt.Printf("Saved output to: %s\n", finalFile)
 }
 
 func fail(err error) {


### PR DESCRIPTION
When I ran `generate.sh` on my machine, the script failed because the corresponding *.swagger.json files doesn't exist for `looprpc/debug.proto`, `auctioneerrpc/auctioneer.proto`, and `auctioneerrpc/hashmail.proto`. At first, I added these files to the `EXCLUDE_PROTOS` var, but this resulted in missing types in the merged JSON file. For example, the `auctioneerrpc.NodeTier` enum is referenced by a few messages in `trader.proto`, but was not in the output because `auctioneer.proto` was excluded.

I'm not sure if this is the best solution, but it passed my sanity check of just skimming the output for references.

