### PR TITLE
config: remove the split site configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ the static sites are deployed.
 
 Follow these steps to run the pipeline locally. You can modify the source
 code for the `merger` tool (golang), markdown generator (Typescript), and
-the markdown templates (in `site/rc/templates`), to alter the generated static
-pages.
+the markdown templates (in `site/tools/templates/`), to alter the generated
+static pages.
 
 **System Requirements**
 
@@ -62,46 +62,51 @@ pages.
 - [protoc](https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.0) v3.6.0 (newer versions may not work as expected)
 - [NodeJS](https://nodejs.org) v16.x or v18.x
 
+#### Initial Setup
+
 1. Clone this repo
    ```bash
    $ git clone https://github.com/lightninglabs/lightning-api-ng.git
    $ cd lightning-api-ng
-   ```
-1. Run the script to generate JSON files for each daemon from their proto files
-   ```bash
-   $ ./generate.sh
    ```
 1. Install NodeJS dependencies
    ```bash
    $ cd site/
    $ yarn
    ```
-1. Run the website locally
-   1. In one terminal, start the Docusaurus site
-      ```bash
-      $ yarn start
-      ```
-   1. In a second terminal, start the script to watch for changes of source
-      files and automatically regenerate the markdown files
-      ```bash
-      # Run one of the commands below.
-      # For LND:
-      $ yarn watch-lnd
-      # For Loop, Pool, Faraday, Taro:
-      $ yarn watch-labs
-      ```
 
-## Building the static website
+#### Active development
 
+1. Run the script to generate JSON files for each daemon from their proto files
+   ```bash
+   $ ./generate.sh
+   ```
+1. In one terminal, start the script to watch for changes of source
+   files and automatically regenerate the markdown files
+   ```bash
+   $ cd site/
+   $ yarn watch
+   ```
+1. In a second terminal, start the Docusaurus site
+   ```bash
+   $ cd site/
+   $ yarn start
+   ```
+1. A new browser window should automatically open http://localhost:3000/api-docs/
+
+#### Building the static website for deployment
+
+1. Run the script to generate JSON files for each daemon from their proto files
+   ```bash
+   $ ./generate.sh
+   ```
 1. Run the script to generate the markdown pages from the JSON files
    ```bash
-   # Run one of the commands below.
-   # For LND:
-   $ BUILD_CONFIG=lnd yarn generate-docs
-   # For Loop, Pool, Faraday, Taro:
-   $ BUILD_CONFIG=labs yarn generate-docs
+   $ cd site/
+   $ yarn generate-docs
    ```
 1. Build the static site
    ```bash
+   $ cd site/
    $ yarn build
    ```

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -8,7 +8,6 @@
 .docusaurus
 .cache-loader
 /docs/api
-build.config.json
 
 # Misc
 .DS_Store

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -3,14 +3,13 @@
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-const buildConfig = require('./build.config.json');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: buildConfig.title,
+  title: 'Lightning Labs API Reference',
   tagline: 'Dinosaurs are cool',
-  url: buildConfig.url,
-  baseUrl: buildConfig.baseUrl,
+  url: 'https://lightning.engineering',
+  baseUrl: '/api-docs/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon-32x32.png',
@@ -67,18 +66,42 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       navbar: {
-        title: buildConfig.title,
+        title: 'Lightning Labs API Reference',
         logo: {
           alt: 'Lightning Labs Logo',
           src: 'img/icon-48x48.png',
         },
         items: [
-          ...buildConfig.repos.map((label) => ({
+          {
             type: 'doc',
-            docId: `api/${label.toLowerCase()}/index`,
+            docId: 'api/lnd/index',
             position: 'left',
-            label,
-          })),
+            label: 'LND',
+          },
+          {
+            type: 'doc',
+            docId: 'api/loop/index',
+            position: 'left',
+            label: 'Loop',
+          },
+          {
+            type: 'doc',
+            docId: 'api/pool/index',
+            position: 'left',
+            label: 'Pool',
+          },
+          {
+            type: 'doc',
+            docId: 'api/faraday/index',
+            position: 'left',
+            label: 'Faraday',
+          },
+          {
+            type: 'doc',
+            docId: 'api/taro/index',
+            position: 'left',
+            label: 'Taro',
+          },
           {
             href: 'https://github.com/lightninglabs/lightning-api-ng/issues',
             label: 'Feedback',
@@ -92,10 +115,26 @@ const config = {
           {
             title: 'Docs',
             items: [
-              ...buildConfig.repos.map((label) => ({
-                label,
-                to: `api/${label.toLowerCase()}`,
-              })),
+              {
+                label: 'LND',
+                to: 'api/lnd',
+              },
+              {
+                label: 'Loop',
+                to: 'api/loop',
+              },
+              {
+                label: 'Pool',
+                to: 'api/pool',
+              },
+              {
+                label: 'Faraday',
+                to: 'api/faraday',
+              },
+              {
+                label: 'Taro',
+                to: 'api/taro',
+              },
             ],
           },
           {
@@ -117,15 +156,28 @@ const config = {
           },
           {
             title: 'Github',
-            items: buildConfig.repos.map((label) => {
-              const repoName = label.toLowerCase();
-              const orgName =
-                repoName === 'lnd' ? 'lightningnetwork' : 'lightninglabs';
-              return {
-                label: `${orgName}/${repoName}`,
-                href: `https://github.com/${orgName}/${repoName}`,
-              };
-            }),
+            items: [
+              {
+                label: 'lightningnetwork/lnd',
+                href: 'http://github.com/lightningnetwork/lnd',
+              },
+              {
+                label: 'lightninglabs/loop',
+                href: 'http://github.com/lightninglabs/loop',
+              },
+              {
+                label: 'lightninglabs/pool',
+                href: 'http://github.com/lightninglabs/pool',
+              },
+              {
+                label: 'lightninglabs/faraday',
+                href: 'http://github.com/lightninglabs/faraday',
+              },
+              {
+                label: 'lightninglabs/pool',
+                href: 'http://github.com/lightninglabs/pool',
+              },
+            ],
           },
         ],
         copyright: `Copyright © ${new Date().getFullYear()} Lightning Labs, Inc.`,

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-docs-site",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -13,8 +13,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "generate-docs": "ts-node ./tools/generate-docs/main.ts",
-    "watch-lnd": "BUILD_CONFIG=lnd nodemon --watch ./tools/generate-docs --watch ./tools/templates --ext ts,md --exec \"yarn generate-docs\"",
-    "watch-labs": "BUILD_CONFIG=labs nodemon --watch ./tools/generate-docs --watch ./tools/templates --ext ts,md --exec \"yarn generate-docs\"",
+    "watch": "nodemon --watch ./tools/generate-docs --watch ./tools/templates --ext ts,md --exec \"yarn generate-docs\"",
     "deploy": "echo \"Deploying to $GC_BUCKET/$GC_PATH\" && yarn push && yarn setcache",
     "push": "gsutil -m rsync -d -r ./build/ gs://$GC_BUCKET/$GC_PATH",
     "clean-bucket": "echo \"Cleaning $GC_BUCKET/$GC_PATH\" && gsutil -m rm -r gs://$GC_BUCKET/$GC_PATH",

--- a/site/tools/generate-docs/constants.ts
+++ b/site/tools/generate-docs/constants.ts
@@ -1,22 +1,5 @@
 import path from 'path';
-import { BuildConfig } from './types';
 
 export const JSON_DIR = path.join('..', 'build');
 export const OUTPUT_DIR = path.join('docs', 'api');
 export const CATEGORY_FILE = '_category_.json';
-
-export const BUILD_CONFIG_PATH = 'build.config.json';
-export const BUILD_CONFIGS: Record<string, BuildConfig> = {
-  lnd: {
-    title: 'LND API Reference',
-    url: 'https://api.lightning.comunnity',
-    baseUrl: '/',
-    repos: ['LND'],
-  },
-  labs: {
-    title: 'Lightning Labs API Reference',
-    url: 'https://lightning.engineering',
-    baseUrl: '/api-docs/',
-    repos: ['Loop', 'Pool', 'Faraday', 'Taro'],
-  },
-};

--- a/site/tools/generate-docs/main.ts
+++ b/site/tools/generate-docs/main.ts
@@ -1,12 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import {
-  BUILD_CONFIG_PATH,
-  BUILD_CONFIGS,
-  CATEGORY_FILE,
-  JSON_DIR,
-  OUTPUT_DIR,
-} from './constants';
+import { CATEGORY_FILE, JSON_DIR, OUTPUT_DIR } from './constants';
 import { Daemon } from './daemon';
 import { templates } from './templates';
 import { JsonDaemon } from './types';
@@ -15,14 +9,7 @@ import { writeCategoryJson } from './utils';
 const { log, error } = console;
 
 const main = async () => {
-  const config = process.env.BUILD_CONFIG;
-  if (!config) {
-    log('Missing list of daemon names. Run:');
-    log('BUILD_CONFIG=[lnd|labs] yarn generate-docs');
-    return;
-  }
   log('Generating Markdown files for Docusaurus');
-  log(`Build Config: ${config}`);
   log(`Output Dir: ${path.resolve(OUTPUT_DIR)}`);
 
   if (fs.pathExistsSync(OUTPUT_DIR)) {
@@ -33,25 +20,10 @@ const main = async () => {
   log('Loading templates');
   templates.load();
 
-  log('Generating build.config.json');
-  const buildConfig = BUILD_CONFIGS[config];
-  if (!buildConfig) {
-    log(`Error: Unable to find build config for '${config}'`);
-    return;
-  }
-  if (process.env.PUBLIC_URL) buildConfig.baseUrl = process.env.PUBLIC_URL;
-  if (process.env.BASE_PATH) buildConfig.baseUrl = process.env.BASE_PATH;
-  fs.writeJsonSync(BUILD_CONFIG_PATH, buildConfig, { spaces: 2 });
-  log(`Wrote ${BUILD_CONFIG_PATH}: `, buildConfig);
-
-  const daemonNames = buildConfig.repos.map((n) => n.toLowerCase());
   log(`Scanning for JSON files in ${path.resolve(JSON_DIR)}`);
   const files = fs
     .readdirSync(JSON_DIR)
-    .filter((filename) => filename.endsWith('.json'))
-    .filter((filename) =>
-      daemonNames.includes(path.basename(filename, '.json'))
-    );
+    .filter((filename) => filename.endsWith('.json'));
   log(`Found ${files.length} JSON files: ${files.join(', ')}`);
   if (!files.length) return;
 

--- a/site/tools/generate-docs/types.ts
+++ b/site/tools/generate-docs/types.ts
@@ -1,10 +1,3 @@
-export interface BuildConfig {
-  title: string;
-  url: string;
-  baseUrl: string;
-  repos: string[];
-}
-
 export interface JsonRestEnum {
   default: string;
   enum: string[];


### PR DESCRIPTION
This PR removes the code and config needed to build the LND docs separate from the other daemons. Now everything is combined into one site.

Closes #5 