### PR TITLE
models: prevent infinite recursion in nested types

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -188,8 +188,10 @@ func (a *App) GetMessage(fullType string) (*Message, error) {
 }
 
 // GetNestedMessages recursively updates a map of all nested messages for the
-// given message.
-func (a *App) GetNestedMessages(message *Message, allMessages map[string]*Message) {
+// given message. The depth parameter is used to limit the recursion.
+func (a *App) GetNestedMessages(message *Message,
+	allMessages map[string]*Message, depth uint8) {
+
 	for _, field := range message.Fields {
 		// Only include the non-native field types (ex: lnrpc.OutPoint)
 		if !strings.Contains(field.FullType, ".") {
@@ -199,9 +201,9 @@ func (a *App) GetNestedMessages(message *Message, allMessages map[string]*Messag
 		msg, _ := a.GetMessage(field.FullType)
 
 		// Add the message to the map if it was found.
-		if msg != nil {
+		if msg != nil && depth > 0 {
 			allMessages[field.FullType] = msg
-			a.GetNestedMessages(msg, allMessages)
+			a.GetNestedMessages(msg, allMessages, depth-1)
 		}
 	}
 }
@@ -225,8 +227,10 @@ func (a *App) GetEnum(fullType string) (*Enum, error) {
 }
 
 // GetNestedEnums recursively updates a map of all nested enums for the given
-// message.
-func (a *App) GetNestedEnums(message *Message, allEnums map[string]*Enum) {
+// message. The depth parameter is used to limit the recursion.
+func (a *App) GetNestedEnums(message *Message, allEnums map[string]*Enum,
+	depth uint8) {
+
 	for _, field := range message.Fields {
 		// Only include the non-native field types (ex: lnrpc.OutPoint)
 		if !strings.Contains(field.FullType, ".") {
@@ -244,9 +248,9 @@ func (a *App) GetNestedEnums(message *Message, allEnums map[string]*Enum) {
 		// If the enum wasn't found, look for a nested message which
 		// may have enum fields.
 		msg, _ := a.GetMessage(field.FullType)
-		if msg != nil {
+		if msg != nil && depth > 0 {
 			// Search the nested messages for more enums.
-			a.GetNestedEnums(msg, allEnums)
+			a.GetNestedEnums(msg, allEnums, depth-1)
 		}
 	}
 }

--- a/models/method.go
+++ b/models/method.go
@@ -102,8 +102,8 @@ func (m *Method) NestedMessages() []*Message {
 	if m.nestedMessages == nil {
 		// Create a new map and populated it with the nested messages.
 		messages := make(map[string]*Message)
-		m.Service.Pkg.App.GetNestedMessages(m.Request(), messages)
-		m.Service.Pkg.App.GetNestedMessages(m.Response(), messages)
+		m.Service.Pkg.App.GetNestedMessages(m.Request(), messages, 10)
+		m.Service.Pkg.App.GetNestedMessages(m.Response(), messages, 10)
 
 		// Convert the map to a slice.
 		m.nestedMessages = make([]*Message, 0, len(messages))
@@ -123,8 +123,8 @@ func (m *Method) NestedEnums() []*Enum {
 	if m.nestedEnums == nil {
 		// Create a new map and populated it with the nested enums.
 		enums := make(map[string]*Enum)
-		m.Service.Pkg.App.GetNestedEnums(m.Request(), enums)
-		m.Service.Pkg.App.GetNestedEnums(m.Response(), enums)
+		m.Service.Pkg.App.GetNestedEnums(m.Request(), enums, 10)
+		m.Service.Pkg.App.GetNestedEnums(m.Response(), enums, 10)
 
 		// Convert the map to a slice.
 		m.nestedEnums = make([]*Enum, 0, len(enums))


### PR DESCRIPTION
A recent commit https://github.com/lightninglabs/taro/commit/ddf1e56e5918d48ce70def61c6e453b4d8367b0f in Taro added a circular reference in the nested gRPC messages of `ListAssetResponse`. The `App.GetNestedMessages()` function recursively looks up all nested messages used by a method. Since there's a circular reference, this produced an infinite loop leading to a panic. I fixed this by just adding a maximum depth of 10 to recurse into the messages.

Adding a log statement in  `App.GetNestedMessages()` shows the circular reference.
```
Looking up type tarorpc.Asset for field tarorpc.ListAssetResponse.assets
Looking up type tarorpc.PrevWitness for field tarorpc.Asset.prev_witnesses
Looking up type tarorpc.SplitCommitment for field tarorpc.PrevWitness.split_commitment
Looking up type tarorpc.Asset for field tarorpc.SplitCommitment.root_asset
Looking up type tarorpc.PrevWitness for field tarorpc.Asset.prev_witnesses
Looking up type tarorpc.SplitCommitment for field tarorpc.PrevWitness.split_commitment
Looking up type tarorpc.Asset for field tarorpc.SplitCommitment.root_asset
```

Here's a portion of the output from the `generate.sh` script
```
Exporting app taro
Exporting package tarorpc
Exporting service Taro
Exporting method MintAsset to ./site/docs/api/taro/taro/mint-asset.mdx
Exporting method ListAssets to ./site/docs/api/taro/taro/list-assets.mdx
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x140206c0380 stack=[0x140206c0000, 0x140406c0000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x100cb4859?, 0x100fd7e40?})
        /opt/homebrew/Cellar/go/1.19/libexec/src/runtime/panic.go:1047 +0x40 fp=0x16f64ad50 sp=0x16f64ad20 pc=0x100a144a0
runtime.newstack()
        /opt/homebrew/Cellar/go/1.19/libexec/src/runtime/stack.go:1103 +0x464 fp=0x16f64af00 sp=0x16f64ad50 pc=0x100a2da64
runtime.morestack()
        /opt/homebrew/Cellar/go/1.19/libexec/src/runtime/asm_arm64.s:316 +0x70 fp=0x16f64af00 sp=0x16f64af00 pc=0x100a40fe0

goroutine 1 [running]:
fmt.(*fmt).padString(0x140003ba1e0?, {0x1400001a9b0, 0x9})
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/format.go:108 +0x27c fp=0x140206c0380 sp=0x140206c0380 pc=0x100aad00c
fmt.(*fmt).fmtS(0x1011405b8?, {0x1400001a9b0?, 0x14000080000?})
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/format.go:359 +0x40 fp=0x140206c03c0 sp=0x140206c0380 pc=0x100aadae0
fmt.(*pp).fmtString(0x0?, {0x1400001a9b0?, 0x140206c0478?}, 0xa2f168?)
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/print.go:477 +0xe4 fp=0x140206c0410 sp=0x140206c03c0 pc=0x100ab0684
fmt.(*pp).printArg(0x140003ba1a0, {0x100d721a0?, 0x14005f34db0}, 0x73)
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/print.go:725 +0x234 fp=0x140206c04b0 sp=0x140206c0410 pc=0x100ab2114
fmt.(*pp).doPrintf(0x140003ba1a0, {0x100cc2398, 0x2f}, {0x140206c0678?, 0x3, 0x3})
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/print.go:1057 +0x21c fp=0x140206c05b0 sp=0x140206c04b0 pc=0x100ab4efc
fmt.Errorf({0x100cc2398, 0x2f}, {0x140206c0678, 0x3, 0x3})
        /opt/homebrew/Cellar/go/1.19/libexec/src/fmt/errors.go:20 +0x54 fp=0x140206c0620 sp=0x140206c05b0 pc=0x100aac814
github.com/lightninglabs/lightning-api-ng/models.(*App).GetMessage(0x140003e2500, {0x1400001a9a8, 0x11})
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:186 +0x14c fp=0x140206c06b0 sp=0x140206c0620 pc=0x100c6a19c
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:199 +0x98 fp=0x140206c0720 sp=0x140206c06b0 pc=0x100c6a2b8
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0790 sp=0x140206c0720 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001aa08?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0800 sp=0x140206c0790 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0870 sp=0x140206c0800 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c08e0 sp=0x140206c0870 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001aa08?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0950 sp=0x140206c08e0 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c09c0 sp=0x140206c0950 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0a30 sp=0x140206c09c0 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001aa08?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0aa0 sp=0x140206c0a30 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0b10 sp=0x140206c0aa0 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0b80 sp=0x140206c0b10 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001aa08?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0bf0 sp=0x140206c0b80 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0c60 sp=0x140206c0bf0 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0cd0 sp=0x140206c0c60 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001aa08?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0d40 sp=0x140206c0cd0 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x140001fc8d0?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0db0 sp=0x140206c0d40 pc=0x100c6a318
github.com/lightninglabs/lightning-api-ng/models.(*App).GetNestedMessages(0x100d88f40?, 0x140406be5b8?, 0x1400001b278?)
        /Users/jamal/dev/lightninglabs/lightning-api-ng/models/app.go:204 +0xf8 fp=0x140206c0e20 sp=0x140206c0db0 pc=0x100c6a318
```