### PR TITLE
config: add Lightning Terminal (LiT) docs

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -65,6 +65,8 @@ POOL_FORK="${POOL_FORK:-lightninglabs}"
 POOL_COMMIT="${POOL_COMMIT:-master}"
 TARO_FORK="${TARO_FORK:-lightninglabs}"
 TARO_COMMIT="${TARO_COMMIT:-main}"
+LIT_FORK="${LIT_FORK:-lightninglabs}"
+LIT_COMMIT="${LIT_COMMIT:-master}"
 PROTO_ROOT_DIR="build/protos"
 
 # Set to 'false' to skip cloning and building each repo 
@@ -87,7 +89,6 @@ PROTO_SRC_DIR=lnrpc
 EXCLUDE_PROTOS="none"
 EXPERIMENTAL_PACKAGES="autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc monitoring peersrpc kvdb_postgres kvdb_etcd"
 INSTALL_CMD="make clean && make install tags=\"$EXPERIMENTAL_PACKAGES\""
-APPEND_TO_FILE=source/lnd.html.md
 GRPC_PORT=10009
 REST_PORT=8080
 compile
@@ -104,7 +105,6 @@ PROTO_SRC_DIR=""
 EXCLUDE_PROTOS="server.proto -not -name common.proto"
 EXPERIMENTAL_PACKAGES=""
 INSTALL_CMD="make install"
-APPEND_TO_FILE=source/loop.html.md
 GRPC_PORT=11010
 REST_PORT=8081
 compile
@@ -121,7 +121,6 @@ PROTO_SRC_DIR=frdrpc
 EXCLUDE_PROTOS="none"
 EXPERIMENTAL_PACKAGES=""
 INSTALL_CMD="make install"
-APPEND_TO_FILE=source/faraday.html.md
 GRPC_PORT=8465
 REST_PORT=8082
 compile
@@ -139,7 +138,6 @@ EXCLUDE_PROTOS="none"
 EXCLUDE_SERVICES="ChannelAuctioneer"
 EXPERIMENTAL_PACKAGES=""
 INSTALL_CMD="make install"
-APPEND_TO_FILE=source/pool.html.md
 GRPC_PORT=12010
 REST_PORT=8281
 compile
@@ -152,12 +150,28 @@ CHECKOUT_COMMIT=$TARO_COMMIT
 COMPONENT=taro
 COMMAND=tarocli
 DAEMON=tarod
-PROTO_SRC_DIR=""
+PROTO_SRC_DIR="tarorpc"
 EXCLUDE_PROTOS="none"
 EXCLUDE_SERVICES=""
 EXPERIMENTAL_PACKAGES=""
 INSTALL_CMD="make install"
-APPEND_TO_FILE=source/taro.html.md
 GRPC_PORT=10029
 REST_PORT=8089
+compile
+
+########################
+## Compile docs for lit
+########################
+REPO_URL="https://github.com/${LIT_FORK}/lightning-terminal"
+CHECKOUT_COMMIT=$LIT_COMMIT
+COMPONENT=lit
+COMMAND=litcli
+DAEMON=litd
+PROTO_SRC_DIR="litrpc"
+EXCLUDE_PROTOS="none"
+EXCLUDE_SERVICES=""
+EXPERIMENTAL_PACKAGES=""
+INSTALL_CMD="make install"
+GRPC_PORT=8443
+REST_PORT=8443
 compile

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -103,6 +103,12 @@ const config = {
             label: 'Taro',
           },
           {
+            type: 'doc',
+            docId: 'api/lit/index',
+            position: 'left',
+            label: 'LiT',
+          },
+          {
             href: 'https://github.com/lightninglabs/lightning-api-ng/issues',
             label: 'Feedback',
             position: 'right',
@@ -134,6 +140,10 @@ const config = {
               {
                 label: 'Taro',
                 to: 'api/taro',
+              },
+              {
+                label: 'LiT',
+                to: 'api/lit',
               },
             ],
           },
@@ -174,8 +184,12 @@ const config = {
                 href: 'http://github.com/lightninglabs/faraday',
               },
               {
-                label: 'lightninglabs/pool',
-                href: 'http://github.com/lightninglabs/pool',
+                label: 'lightninglabs/taro',
+                href: 'http://github.com/lightninglabs/taro',
+              },
+              {
+                label: 'lightninglabs/lit',
+                href: 'http://github.com/lightninglabs/lit',
               },
             ],
           },

--- a/templates/apps/lit.md
+++ b/templates/apps/lit.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 6
+---
+
+# Lightning Terminal (LiT)
+
+Welcome to the API reference documentation for Lightning Terminal (LiT).
+
+Lightning Terminal (LiT) is a browser-based interface for managing channel liquidity.
+
+## Features
+
+- Visualize your channels and balances
+- Perform submarine swaps via the [Lightning Loop](https://lightning.engineering/loop) service
+- Classify channels according to your node's operating mode
+- Run a single binary that integrates [`loopd`](https://github.com/lightninglabs/loop),
+  [`poold`](https://github.com/lightninglabs/pool) and
+  [`faraday`](https://github.com/lightninglabs/faraday) daemons all in one
+- Access a preview release of the Pool UI
+- Use Pool to earn sats by opening channels to those needing inbound liquidity
+
+## Usage
+
+Learn how to install, configure, and use LiT by viewing the documentation in the [Builder's Guide](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/get-lit).
+
+{{template "shared.md" .}}


### PR DESCRIPTION
Add API docs for Lightning Terminal.

Many RPC methods in the LiT proto files don't have comments yet, so some descriptions are missing. We should also add the CLI commands to the comments in order to get the Shell documentation to populate for each RPC.

Depends on https://github.com/lightninglabs/lightning-terminal/pull/522. You'll need to generate the docs using the command below until that PR is merged.
```sh
$ LIT_FORK=ellemouton LIT_COMMIT=litREST ./generate.sh 
```