### PR TITLE
site: fix missing deprecated badges

### DIFF
--- a/site/src/components/MessageField.tsx
+++ b/site/src/components/MessageField.tsx
@@ -19,7 +19,7 @@ const MessageField: React.FC<Props> = ({ name, children }) => {
   if (!!children) cn = `${cn} ${styles.collapsible}`;
   let deprecated = false;
   React.Children.forEach(children, (child) => {
-    if (typeof child === 'string' && child.includes('deprecated'))
+    if (typeof child === 'string' && child.toLowerCase().includes('deprecated'))
       deprecated = true;
   });
 


### PR DESCRIPTION
I realized that the "deprecated" badges for message fields were not being displayed on the site. This small tweak fixes the problem.

Here's what the deprecated fields should look like.
![image](https://user-images.githubusercontent.com/1356600/226697092-932cad9f-5c0a-43fb-8eec-e44cac15779c.png)
