### PR TITLE
models: Fix a few issues with mapping from proto/swagger files

### DIFF
--- a/defs/api_rest_mapping.go
+++ b/defs/api_rest_mapping.go
@@ -28,7 +28,9 @@ type RESTParameter struct {
 }
 
 type RESTSchema struct {
-	Ref string `json:"$ref"`
+	Ref        string                   `json:"$ref"`
+	Type       string                   `json:"type"`
+	Properties map[string]*RESTProperty `json:"properties"`
 }
 
 type RESTType struct {

--- a/models/field.go
+++ b/models/field.go
@@ -80,7 +80,7 @@ func (f *Field) EncodingTip() string {
 				f.RestPlacement),
 			"<br />",
 			fmt.Sprintf("See [REST Encoding]"+
-				"(/docs/api/%s/#rest-encoding).",
+				"(/api/%s/#rest-encoding).",
 				f.Message.Package.App.Name),
 			"</Tip>",
 		}, "")

--- a/models/method.go
+++ b/models/method.go
@@ -40,14 +40,12 @@ type Method struct {
 // NewMethod creates a new method from a method definition.
 func NewMethod(methodDef *defs.ServiceMethod, service *Service) *Method {
 	m := &Method{
-		Service:     service,
-		Name:        methodDef.Name,
-		Description: parseDescription(methodDef.Description),
-		Source:      methodDef.Source,
-		CommandLine: methodDef.CommandLine,
-		CommandLineHelp: markdown.CleanDescription(
-			methodDef.CommandLineHelp, false,
-		),
+		Service:            service,
+		Name:               methodDef.Name,
+		Description:        parseDescription(methodDef.Description),
+		Source:             methodDef.Source,
+		CommandLine:        methodDef.CommandLine,
+		CommandLineHelp:    methodDef.CommandLineHelp,
 		RequestType:        methodDef.RequestType,
 		RequestFullType:    methodDef.RequestFullType,
 		RequestTypeSource:  methodDef.RequestTypeSource,


### PR DESCRIPTION
This PR resolves a few issues in the docs site mapping of the source `.proto` and `.swagger.json` files.

- add support for a structural change in the `tapd` swagger files ([tap PR #847](https://github.com/lightninglabs/taproot-assets/pull/847))
- fix improper encoding of command line help text ([#24](https://github.com/lightninglabs/lightning-api-ng/issues/24))
- fix REST Encoding link for bytes fields ([#27](https://github.com/lightninglabs/lightning-api-ng/issues/27))