### PR TITLE
site: ensure all site links include a trailing slash

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -10,6 +10,7 @@ const config = {
   tagline: 'Dinosaurs are cool',
   url: 'https://lightning.engineering',
   baseUrl: '/api-docs/',
+  trailingSlash: true,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon-32x32.png',


### PR DESCRIPTION
Closes #31 & #32.

Updates the Docusaurus [config](https://docusaurus.io/docs/api/docusaurus-config#trailingSlash) to append trailing slashes to all links throughout the site. This will avoid gcloud redirects to `/index.html` when a page is reloaded or a link is pasted into a different browser.