### PR TITLE
models: fix broken RestEndpoint link urls

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -150,7 +150,7 @@ func (a *App) RestEndpoints() []*RestEndpoint {
 			RestPath:   method.RestMapping.Path,
 			RestMethod: method.RestMapping.Method,
 			LinkUrl: fmt.Sprintf(
-				"%s/%s",
+				"../%s/%s/",
 				markdown.ToKebabCase(method.Service.Name),
 				markdown.ToKebabCase(method.Name),
 			),


### PR DESCRIPTION
This is a follow-up to #34 which fixes the link urls on the REST Endpoints pages. It was discovered by the build failing during deployment. I should have done a full build locally to catch this. 

I've confirmed that the build does now succeed after this fix and the links are working properly.