### PR TITLE
generate: reintroduce looprpc

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -38,7 +38,8 @@ function initrepo() {
   fi
 
   pushd $PROTO_DIR
-  proto_files=$(find . -name '*.proto' -not -name $EXCLUDE_PROTOS)
+  proto_files=$(find . -name '*.proto' -not -path "$EXCLUDE_PROTOS")
+  
   protoc -I. -I/usr/local/include $INCLUDE_FLAG \
     --doc_out=json,generated.json:. $proto_files
   popd
@@ -108,8 +109,8 @@ CHECKOUT_COMMIT=$LOOP_COMMIT
 COMPONENT=loop
 COMMAND=loop
 DAEMON=loopd
-PROTO_SRC_DIR="swapserverrpc"
-EXCLUDE_PROTOS="server.proto -not -name common.proto"
+PROTO_SRC_DIR=""
+EXCLUDE_PROTOS="./swapserverrpc/*"
 EXPERIMENTAL_PACKAGES=""
 INSTALL_CMD="make install"
 GRPC_PORT=11010


### PR DESCRIPTION
A previous PR fixed an error for `swapserverrpc` docs generation but broke `looprpc` docs generation. As a result, there are no docs for `looprpc.*` RPC calls.

The core of the issue is that if you do not specify an explicit source directory, the root of the `loop` repo is used which breaks the relative imports.

This patch adds a `sed` patcher that does an in-place replacement of these broken imports. Thus, the source directory can be `loop` itself -- readding the removed `looprpc` documentation.